### PR TITLE
fix: import pdf-parse safely

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,11 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import pdfParse from "pdf-parse";
+import { createRequire } from "module";
+import type pdfParseType from "pdf-parse";
+
+const require = createRequire(import.meta.url);
+const pdfParse: typeof pdfParseType = require("pdf-parse");
 
 // Tool name constants
 const TOOL_GET_BY_DOI = "unpaywall_get_by_doi" as const;


### PR DESCRIPTION
## Summary
- use createRequire to load pdf-parse without triggering debug code that expects local test data

## Testing
- `npm run build`
- `timeout 1 node dist/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68adc25a58ac832096c542342764c14d