### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ An MCP (Model Context Protocol) server exposing Unpaywall tools so AI clients ca
 - Retrieve best OA fulltext links
 - Download and extract text from OA PDFs
 
+<a href="https://glama.ai/mcp/servers/@ElliotPadfield/unpaywall-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ElliotPadfield/unpaywall-mcp/badge" alt="Unpaywall Server MCP server" />
+</a>
+
 ## Quickstart (npx)
 
 Add this to your MCP client config (Claude Desktop example):


### PR DESCRIPTION
This PR adds a badge for the [Unpaywall MCP Server](https://glama.ai/mcp/servers/@ElliotPadfield/unpaywall-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ElliotPadfield/unpaywall-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ElliotPadfield/unpaywall-mcp/badge" alt="Unpaywall Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.