### PR TITLE
fix: MCP-valid content type + swap /v2/search backend to OpenAlex (#4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,17 @@
         "@modelcontextprotocol/sdk": "^1.17.3",
         "pdf-parse": "^1.1.1"
       },
+      "bin": {
+        "unpaywall-mcp": "bin/unpaywall-mcp.js"
+      },
       "devDependencies": {
         "@types/node": "^20.12.7",
         "@types/pdf-parse": "^1.1.5",
         "tsx": "^4.16.2",
         "typescript": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,12 @@ async function searchTitlesViaOpenAlex(args: { query: string; email: string; is_
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 20_000);
   try {
-    const filterParts = [`title.search:${query}`];
+    // OpenAlex joins filters with commas, so any comma inside the query would
+    // be parsed as a filter delimiter (verified: produces HTTP 400 "Invalid
+    // query parameter"). Collapse commas to spaces — OpenAlex AND-joins words
+    // within a single title.search term, which matches Unpaywall's default.
+    const safeQuery = query.replace(/,/g, " ").replace(/\s+/g, " ").trim();
+    const filterParts = [`title.search:${safeQuery}`];
     if (typeof is_oa === "boolean") filterParts.push(`is_oa:${is_oa}`);
     const params = new URLSearchParams();
     params.set("filter", filterParts.join(","));
@@ -165,7 +170,10 @@ function mapOpenAlexWorksToUnpaywallSearch(data: any, query: string) {
     const title: string = w?.title ?? w?.display_name ?? "";
     const openAccess = w?.open_access ?? {};
     const best = mapOpenAlexLocationToUnpaywall(w?.best_oa_location);
-    const locs: any[] = Array.isArray(w?.locations) ? w.locations : [];
+    // Unpaywall's oa_locations is OA-only by definition; OpenAlex's
+    // work.locations returns every location including closed publisher landing
+    // pages, so filter on is_oa first to avoid mislabeling paywalled links.
+    const locs: any[] = Array.isArray(w?.locations) ? w.locations.filter((l: any) => l?.is_oa === true) : [];
     const oa_locations = locs.map(mapOpenAlexLocationToUnpaywall).filter((l) => l && (l.url || l.url_for_pdf));
     return {
       response: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,7 +225,7 @@ async function main() {
         const doi = normalizeDoi(rawDoi);
         const data = await fetchUnpaywallByDoi(doi, email);
         return {
-          content: [{ type: "json", json: data }],
+          content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
         };
       }
       if (tool === TOOL_SEARCH_TITLES) {
@@ -241,7 +241,7 @@ async function main() {
         const page = args.page && Number.isFinite(args.page) ? Math.max(1, Math.floor(Number(args.page))) : undefined;
         const is_oa = typeof args.is_oa === "boolean" ? args.is_oa : undefined;
         const data = await searchUnpaywallTitles({ query, email, is_oa, page });
-        return { content: [{ type: "json", json: data }] };
+        return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
       }
       if (tool === TOOL_GET_FULLTEXT_LINKS) {
         const args = (req.params.arguments ?? {}) as Partial<GetByDoiArgs>;
@@ -270,7 +270,7 @@ async function main() {
           best_oa_location: best,
           oa_locations: locations,
         };
-        return { content: [{ type: "json", json: result }] };
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
       if (tool === TOOL_FETCH_PDF_TEXT) {
         const args = (req.params.arguments ?? {}) as Partial<FetchPdfTextArgs>;
@@ -315,7 +315,7 @@ async function main() {
             metadata: parsed.metadata ?? undefined,
           },
         };
-        return { content: [{ type: "json", json: output }] };
+        return { content: [{ type: "text", text: JSON.stringify(output, null, 2) }] };
       }
 
       return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,26 +95,100 @@ async function downloadPdfAsBuffer(url: string, maxBytes = 30 * 1024 * 1024) {
   }
 }
 
-async function searchUnpaywallTitles(args: { query: string; email: string; is_oa?: boolean; page?: number }) {
+// Unpaywall's own /v2/search endpoint has been returning HTTP 500 for every
+// query since at least the May 2025 "Walden" rewrite, which appears to have
+// ported only the DOI lookup path forward. OpenAlex (now Unpaywall's parent
+// codebase) exposes an equivalent title search via /works that returns the
+// same OA fields. We hit that and remap the response into the Unpaywall
+// search shape so existing callers continue to work unchanged.
+async function searchTitlesViaOpenAlex(args: { query: string; email: string; is_oa?: boolean; page?: number }) {
   const { query, email, is_oa, page } = args;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 20_000);
   try {
+    const filterParts = [`title.search:${query}`];
+    if (typeof is_oa === "boolean") filterParts.push(`is_oa:${is_oa}`);
     const params = new URLSearchParams();
-    params.set("query", query);
-    if (typeof is_oa === "boolean") params.set("is_oa", String(is_oa));
+    params.set("filter", filterParts.join(","));
+    params.set("per-page", "50"); // match Unpaywall's documented page size
     if (page && Number.isFinite(page) && page > 1) params.set("page", String(Math.floor(page)));
-    params.set("email", email);
-    const url = `https://api.unpaywall.org/v2/search?${params.toString()}`;
+    if (email) params.set("mailto", email);
+    const url = `https://api.openalex.org/works?${params.toString()}`;
     const resp = await fetch(url, { signal: controller.signal, headers: { "Accept": "application/json" } });
     if (!resp.ok) {
       const text = await resp.text().catch(() => "");
-      throw new Error(`Unpaywall search HTTP ${resp.status}: ${text.slice(0, 400)}`);
+      throw new Error(`OpenAlex search HTTP ${resp.status}: ${text.slice(0, 400)}`);
     }
-    return await resp.json();
+    const data: any = await resp.json();
+    return { ...mapOpenAlexWorksToUnpaywallSearch(data, query), _source: "openalex" };
   } finally {
     clearTimeout(timeout);
   }
+}
+
+function mapOpenAlexLocationToUnpaywall(loc: any) {
+  if (!loc || typeof loc !== "object") return null;
+  const sourceType = loc?.source?.type; // "journal" | "repository" | "ebook platform" | "book series" | ...
+  const host_type = sourceType === "repository" ? "repository" : sourceType ? "publisher" : undefined;
+  return {
+    url: loc.landing_page_url ?? null,
+    url_for_pdf: loc.pdf_url ?? null,
+    url_for_landing_page: loc.landing_page_url ?? null,
+    license: loc.license ?? null,
+    version: loc.version ?? null,
+    host_type: host_type ?? null,
+    is_best: !!loc.is_oa && !!loc.pdf_url,
+  };
+}
+
+function buildSnippet(title: string, query: string): string {
+  if (!title) return "";
+  const tokens = Array.from(
+    new Set(
+      query
+        .toLowerCase()
+        .split(/[^a-z0-9]+/i)
+        .filter((t) => t.length >= 2),
+    ),
+  );
+  if (tokens.length === 0) return title;
+  const escaped = tokens.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const re = new RegExp(`(${escaped.join("|")})`, "gi");
+  return title.replace(re, "<b>$1</b>");
+}
+
+function mapOpenAlexWorksToUnpaywallSearch(data: any, query: string) {
+  const works: any[] = Array.isArray(data?.results) ? data.results : [];
+  const results = works.map((w) => {
+    const doiUrl: string | null = w?.doi ?? null;
+    const normalizedDoi = doiUrl ? doiUrl.replace(/^https?:\/\/(dx\.)?doi\.org\//i, "") : null;
+    const title: string = w?.title ?? w?.display_name ?? "";
+    const openAccess = w?.open_access ?? {};
+    const best = mapOpenAlexLocationToUnpaywall(w?.best_oa_location);
+    const locs: any[] = Array.isArray(w?.locations) ? w.locations : [];
+    const oa_locations = locs.map(mapOpenAlexLocationToUnpaywall).filter((l) => l && (l.url || l.url_for_pdf));
+    return {
+      response: {
+        doi: normalizedDoi,
+        doi_url: doiUrl,
+        title,
+        is_oa: typeof openAccess.is_oa === "boolean" ? openAccess.is_oa : null,
+        oa_status: openAccess.oa_status ?? null,
+        best_oa_location: best,
+        oa_locations,
+      },
+      score: typeof w?.relevance_score === "number" ? w.relevance_score : null,
+      snippet: buildSnippet(title, query),
+    };
+  });
+  return {
+    results,
+    meta: {
+      count: data?.meta?.count ?? null,
+      page: data?.meta?.page ?? null,
+      per_page: data?.meta?.per_page ?? null,
+    },
+  };
 }
 
 async function main() {
@@ -149,7 +223,8 @@ async function main() {
         },
         {
           name: TOOL_SEARCH_TITLES,
-          description: "Search Unpaywall for article titles matching a query. Supports optional is_oa filter and pagination (50 results per page).",
+          description:
+            "Search article titles and return Unpaywall-style open-access metadata for each hit. Supports optional is_oa filter and pagination (50 results per page). Backed by OpenAlex's /works endpoint because Unpaywall's own /v2/search has been returning HTTP 500 since its May 2025 rewrite; response shape still mirrors Unpaywall's documented search result (results[].response is a DOI record, results[].score, results[].snippet).",
           inputSchema: {
             type: "object",
             properties: {
@@ -240,7 +315,7 @@ async function main() {
         }
         const page = args.page && Number.isFinite(args.page) ? Math.max(1, Math.floor(Number(args.page))) : undefined;
         const is_oa = typeof args.is_oa === "boolean" ? args.is_oa : undefined;
-        const data = await searchUnpaywallTitles({ query, email, is_oa, page });
+        const data = await searchTitlesViaOpenAlex({ query, email, is_oa, page });
         return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
       }
       if (tool === TOOL_GET_FULLTEXT_LINKS) {


### PR DESCRIPTION
Fixes #4. Two related fixes bundled because the smoke test surfaced both.

## 1. Content type `"json"` → `"text"` (the reported bug)
The tool handlers were returning `{ type: "json", json: ... }`, which is not a content type defined by the MCP protocol — valid types are `"text"`, `"image"`, `"audio"`, `"resource"`, and `"resource_link"`. Clients like Claude Code reject the response with a schema validation error. Switched all four successful returns to `{ type: "text", text: JSON.stringify(data, null, 2) }`, matching the fix suggested in the issue. Error paths already used `type: "text"` and were left unchanged.

## 2. `unpaywall_search_titles` backend → OpenAlex `/works`
While verifying the content-type fix end-to-end, I found that Unpaywall's own `/v2/search` endpoint has been returning HTTP 500 for every query — verified against `dinosaur`, `open access`, `graphene`, `covid`, `biology`, `hungry hippos`, with and without trailing slash, with and without `is_oa`. This appears to be an upstream regression from the May 2025 "Walden" rewrite in which Unpaywall was reimplemented on top of OpenAlex; the companion service [`ourresearch/openalex-unpaywall`](https://github.com/ourresearch/openalex-unpaywall) only implements `/unpaywall/<doi>`, with no search route. The DOI endpoint still works fine.

Since Unpaywall now runs as a subroutine of OpenAlex, the tool now routes title search through OpenAlex's `/works` endpoint:

- URL: `https://api.openalex.org/works?filter=title.search:<query>[,is_oa:<bool>]&per-page=50&page=<n>&mailto=<email>`
- Response is remapped into the documented Unpaywall search shape so the public tool contract is unchanged:
  - `results[].response` — a DOI-style record with `doi`, `doi_url`, `title`, `is_oa`, `oa_status`, `best_oa_location`, `oa_locations`
  - `results[].score` — OpenAlex `relevance_score`
  - `results[].snippet` — title with matched query tokens wrapped in `<b>...</b>` (best-effort, since OpenAlex doesn't return highlighted snippets)
- `meta.count`, `meta.page`, `meta.per_page` are surfaced
- Adds a top-level `_source: "openalex"` marker for transparency
- OA locations are mapped: `pdf_url → url_for_pdf`, `landing_page_url → url/url_for_landing_page`, `source.type → host_type` (`repository` | `publisher`), `license`/`version` pass through

## Verification
- `npm run build` — clean TypeScript compile. No remaining `type: "json"` in `dist/index.js`.
- **Smoke test** (stdio) — all 23 assertions pass:
  - `initialize` + `tools/list` lists all four tools.
  - `unpaywall_get_by_doi` (`10.1038/nphys1170`) → `type: "text"`, payload parses as JSON with `doi` + `is_oa`.
  - `unpaywall_get_fulltext_links` → `type: "text"`, payload has `best_pdf_url` / `best_open_url`.
  - `unpaywall_search_titles` (`hungry hippos`) → `type: "text"`, payload has `results[]` with `response.doi`, `response.title`, `response.is_oa` (boolean), `score`, `snippet` containing `<b>` highlights, `meta.count`, `_source: "openalex"`.
  - `unpaywall_search_titles` with `is_oa: true` → every returned result has `response.is_oa === true`.
- **Integration test** — round-trip a DOI from the new search backend through `unpaywall_get_by_doi` and `unpaywall_get_fulltext_links`: DOIs from OpenAlex resolve cleanly in Unpaywall's DOI endpoint, confirming the two tools still compose after the backend swap.

## Test plan
- [x] `npm run build` succeeds
- [x] Stdio smoke test: initialize + tools/list + tools/call for `unpaywall_get_by_doi`, `unpaywall_get_fulltext_links`, `unpaywall_search_titles` (both default and `is_oa:true`)
- [x] Integration test: search → get_by_doi → get_fulltext_links round trip
- [ ] `unpaywall_fetch_pdf_text` was not exercised end-to-end (left out of the smoke test to avoid network flakiness on large PDF downloads). The content-type fix is the same one-line change applied to the other three tools; no PDF-parse logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)