### PR TITLE
chore(release): prep 0.1.2 — version bump, publish fix, README

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,8 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
-      - run: npm test
+      - run: npm run build
+      - run: npm test --if-present
 
   publish-npm:
     needs: build

--- a/README.md
+++ b/README.md
@@ -29,25 +29,24 @@ Add this to your MCP client config (Claude Desktop example):
 
 Then try the tools: `unpaywall_search_titles`, `unpaywall_get_fulltext_links`, `unpaywall_fetch_pdf_text`.
 
+You don't need to clone this repo or run `npm install` — `npx` handles fetching and caching on first call.
+
 ## Requirements
 
-- Node.js 18+
-- An email address for Unpaywall requests (they require it for polite usage).
+- Node.js 18+ (for `npx`)
+- An email address for Unpaywall / OpenAlex requests (required by Unpaywall, used for the OpenAlex polite pool).
 
-## Setup
+## Local development (contributors only)
+
+End users should use the npx config above. Contributors building from source:
 
 ```bash
-# Install deps
 npm install
-
-# Build
 npm run build
-
-# Run (stdio transport, as required by MCP clients)
-UNPAYWALL_EMAIL=you@example.com npm start
+UNPAYWALL_EMAIL=you@example.com npm start   # stdio transport, as required by MCP clients
 ```
 
-For development with hot-run (no build step):
+Hot-run (no build step):
 
 ```bash
 UNPAYWALL_EMAIL=you@example.com npm run dev
@@ -65,13 +64,14 @@ UNPAYWALL_EMAIL=you@example.com npm run dev
 
 ### unpaywall_search_titles
 
-- Description: Search Unpaywall for article titles matching a query (50 results/page)
+- Description: Search article titles and return Unpaywall-style OA metadata for each hit (50 results/page)
 - Input schema:
   - `query` (string, required): title query
   - `is_oa` (boolean, optional): if true, only OA results; if false, only closed; omit for all
   - `page` (integer >= 1, optional): page number
   - `email` (string, optional): overrides `UNPAYWALL_EMAIL`
-- Output: JSON search results from `GET https://api.unpaywall.org/v2/search`
+- Output: JSON matching the Unpaywall search shape — `results[].response` is a DOI-style record (`doi`, `title`, `is_oa`, `oa_status`, `best_oa_location`, `oa_locations`), with `score` and `snippet` per result. `_source: "openalex"` marks the upstream.
+- Note: Backed by OpenAlex's `/works` endpoint because Unpaywall's own `/v2/search` has been returning HTTP 500 since its May 2025 rewrite. Unpaywall now runs as a subroutine of OpenAlex, so this is the canonical modern equivalent.
 
 ### unpaywall_get_fulltext_links
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unpaywall-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": false,
   "description": "MCP server for Unpaywall: DOI metadata, title search, OA links, and PDF text extraction",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,7 @@ async function main() {
   const server = new Server(
     {
       name: "unpaywall-mcp",
-      version: "0.1.1",
+      version: "0.1.2",
     },
     {
       capabilities: {


### PR DESCRIPTION
Release prep for 0.1.2, on top of #5 (already merged to `main`).

## Why this needs to be its own PR
#5 was merged between my last two pushes, so this release-prep commit landed on the stale feature branch. Reopening it cleanly against `main`.

## Summary
- **Bump to 0.1.2** — patch for the MCP content-type fix and OpenAlex search backend swap that landed in #5. Also updates the server's internal `version` string in `src/index.ts:124` so it stops drifting from `package.json`.
- **Fix `.github/workflows/npm-publish.yml`** — the `build` job runs `npm test`, but there is no `test` script, so the workflow would fail with `npm error Missing script: "test"` on `release: created` and block the `publish-npm` step. Replace with `npm run build` (real CI value — verifies the TypeScript compiles before publishing) plus `npm test --if-present` so a future test script plugs in without a workflow edit.
- **README cleanup** — reframe the "Setup" block as "Local development (contributors only)" so end users clearly land on the `npx -y unpaywall-mcp` config (this is the "modern-style, no `npm install`" path the MCP SDK already supports). Add a one-line note in the Quickstart confirming no clone / no install is needed. Update the `unpaywall_search_titles` output description to match the new shape delivered in #5 (`results[].response`, `results[].score`, `results[].snippet`, `_source`) and call out the OpenAlex-backed implementation.

## Release plan after merge
1. Merge this PR.
2. Create a GitHub release tagged `v0.1.2` — `.github/workflows/npm-publish.yml` triggers on `release: created`, builds, and runs `npm publish`.
3. `npm view unpaywall-mcp version` should then show `0.1.2`.

## Test plan
- [x] `npm run build` succeeds at 0.1.2 (tsc clean).
- [x] Stdio smoke test still passes 30/30 after the version bump (same test run as #5).
- [x] Workflow YAML is syntactically valid (inspected).
- [ ] After merge + release, confirm the workflow run succeeds and `npm view unpaywall-mcp version` === `0.1.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)